### PR TITLE
Install crossplane in e2e job and run on PRs

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -3,6 +3,7 @@ name: crossplane-e2e
 on:
   schedule:
     - cron: '0 12 * * *'
+  pull_request: {}
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,12 +12,24 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Crossplane Repo
+        uses: actions/checkout@v2
         with:
           repository: crossplane/crossplane
           ref: master
-      - uses: engineerd/setup-kind@v0.5.0
+      - name: Setup Kind
+        uses: engineerd/setup-kind@v0.5.0
         with:
           version: ${{ env.KIND_VERSION }}
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@v1
+      - name: Create Namespace
+        run: kubectl create namespace crossplane-system
+        shell: bash
+      - name: Install Crossplane from latest on Master
+        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel
+        shell: bash
       - name: Run E2E Tests
         run: go test -timeout 10m -v --tags=e2e ./test/e2e/...


### PR DESCRIPTION
Adds steps to install latest Crossplane from `master`. Also updates to run on PRs to this repo for the time-being.