### PR TITLE
Add core crossplane upgrade test.

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -1,0 +1,44 @@
+name: core-crossplane-upgrade
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  KIND_VERSION: 'v0.7.0'
+
+jobs:
+  crossplane-upgrade-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crossplane Release 1.1
+        uses: actions/checkout@v2
+        with:
+          repository: crossplane/crossplane
+          ref: release-1.1
+      - name: Setup Kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+      - name: Create Namespace
+        run: kubectl create namespace crossplane-system
+        shell: bash
+      - name: Install Crossplane from Stable
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.0
+        shell: bash
+      - name: Run E2E Tests for stable
+        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...
+      - name: Checkout Crossplane Master
+        uses: actions/checkout@v2
+        with:
+          repository: crossplane/crossplane
+          ref: master
+      - name: Update Crossplane to latest build from master
+        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm upgrade crossplane --namespace crossplane-system crossplane-master/crossplane --devel
+        shell: bash
+      - name: Run E2E Tests for master
+        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...


### PR DESCRIPTION
Adds periodic upgrade tests of supported Crossplane versions to the next version (including the latest builds). Right now we will be running:

Upgrade from v1.1.0 to latest build on master.

The workflow performs the following tasks: 
1. Sets up Kind Cluster and Installs Helm
2. Creates a namespace `crossplane-system` and installs Crossplane `v1.1.0` from the stable channel.
3. Clones release-1.1.0 branch from Crossplane repo and runs the e2e tests. 
4. Upgrades Crossplane to the latest development build from the master channel. 
5. Clones master branch of Crossplane repo and runs the e2e tests again. 

Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>