### PR TITLE
Update provider upgrade test to use latest releases

### DIFF
--- a/config/provider/conformance.yml
+++ b/config/provider/conformance.yml
@@ -1,14 +1,14 @@
 providers:
 - package: crossplane/provider-gcp
   upgrade:
-  - initial: "v0.16.0"
+  - initial: "v0.17.1"
     final: "master"
 - package: crossplane/provider-aws
   upgrade:
-  - initial: "v0.17.0"
+  - initial: "v0.18.1"
     final: "master"
 - package: crossplane/provider-azure
   upgrade:
-  - initial: "v0.15.0"
+  - initial: "v0.16.1"
     final: "master"
   


### PR DESCRIPTION
Updates provider upgrades tests to use the latest stable version for
testing upgrade to master.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>