### PR TITLE
Do not run crossplane e2e tests in parallel

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
         run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.0
         shell: bash
       - name: Run E2E Tests for stable
-        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...
+        run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...
       - name: Checkout Crossplane Master
         uses: actions/checkout@v2
         with:
@@ -41,4 +41,4 @@ jobs:
         run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm upgrade crossplane --namespace crossplane-system crossplane-master/crossplane --devel
         shell: bash
       - name: Run E2E Tests for master
-        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...
+        run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -33,7 +33,7 @@ jobs:
         run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel
         shell: bash
       - name: Run E2E Tests
-        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...
+        run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...
   e2e-tests-stable:
     runs-on: ubuntu-latest
     steps:
@@ -57,4 +57,4 @@ jobs:
         run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
         shell: bash
       - name: Run E2E Tests
-        run: go test -timeout 10m -v --tags=e2e ./test/e2e/...
+        run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...


### PR DESCRIPTION
Updates crossplane e2e tests to not run in parallel due to the fact that
the various e2e test packages can conflict in behavior when running
simultaneously. Note that provider upgrade tests still run in parallel
because they do not conflict.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>