### PR TITLE
Wait for installs and upgrades to become ready before running tests

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -28,7 +28,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.0
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.0 --wait
         shell: bash
       - name: Run E2E Tests for stable
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...
@@ -38,7 +38,7 @@ jobs:
           repository: crossplane/crossplane
           ref: master
       - name: Update Crossplane to latest build from master
-        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm upgrade crossplane --namespace crossplane-system crossplane-master/crossplane --devel
+        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm upgrade crossplane --namespace crossplane-system crossplane-master/crossplane --devel --wait
         shell: bash
       - name: Run E2E Tests for master
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  KIND_VERSION: 'v0.7.0'
+  KIND_VERSION: 'v0.11.1'
 
 jobs:
   crossplane-upgrade-test:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  KIND_VERSION: 'v0.7.0'
+  KIND_VERSION: 'v0.11.1'
 
 jobs:
   e2e-tests-latest:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -30,7 +30,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Master
-        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel
+        run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --wait
         shell: bash
       - name: Run E2E Tests
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...
@@ -54,7 +54,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --wait
         shell: bash
       - name: Run E2E Tests
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -27,7 +27,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --wait
         shell: bash
       - name: Run Provider Upgrade Tests
         run: go test -timeout 10m -v --tags=e2e_provider ./test/...

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  KIND_VERSION: 'v0.7.0'
+  KIND_VERSION: 'v0.11.1'
 
 jobs:
   provider-upgrade-crossplane-stable:


### PR DESCRIPTION
Adds the --wait flag to all installs and upgrades to verify that pods
are running before running tests. This is necessary due to the fact that
crossplane now manages its own CRDs, so they may not be present until
after the core crossplane init container exits.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>