### PR TITLE
Use go 1.16 in all workflows

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  GO_VERSION: '1.16'
   KIND_VERSION: 'v0.11.1'
 
 jobs:
@@ -18,6 +19,10 @@ jobs:
         with:
           repository: crossplane/crossplane
           ref: release-1.1
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  GO_VERSION: '1.16'
   KIND_VERSION: 'v0.11.1'
 
 jobs:
@@ -18,6 +19,10 @@ jobs:
         with:
           repository: crossplane/crossplane
           ref: master
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:
@@ -42,6 +47,10 @@ jobs:
         with:
           repository: crossplane/crossplane
           ref: release-1.0
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
+  GO_VERSION: '1.16'
   KIND_VERSION: 'v0.11.1'
 
 jobs:
@@ -15,6 +16,10 @@ jobs:
     steps:
       - name: Checkout Test Repo
         uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Setup Kind
         uses: engineerd/setup-kind@v0.5.0
         with:


### PR DESCRIPTION
Updates all workflows to use go 1.16 such that the version matches the
e2e tests we are running from the crossplane repo. These tests are
currently failing due to features that are only enabled in go 1.16.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>