### PR TITLE
changed the versions of providers so that the provider upgrade test is working with recent versions

### DIFF
--- a/config/provider/conformance.yml
+++ b/config/provider/conformance.yml
@@ -1,14 +1,14 @@
 providers:
 - package: crossplane/provider-gcp
   upgrade:
-  - initial: "v0.17.1"
+  - initial: "v0.21.0"
     final: "master"
 - package: crossplane/provider-aws
   upgrade:
-  - initial: "v0.18.1"
+  - initial: "v0.29.0"
     final: "master"
 - package: crossplane/provider-azure
   upgrade:
-  - initial: "v0.16.1"
+  - initial: "v0.19.0"
     final: "master"
   


### PR DESCRIPTION
We debugged the failure of provider-upgrade tests and found that they were using old versions which no longer can be upgraded to the current latest versions. For example in provider-gcp this was the error we received 

```
Warning  SyncPackage        9s (x3 over 2m39s)     packages/providerrevision.pkg.crossplane.io  cannot establish control of object: CustomResourceDefinition.apiextensions.k8s.io "nodepools.container.gcp.crossplane.io" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions
```
**NOTE**
we will be verifying the tests again from the CI run on this PR.

