### PR TITLE
upgraded versions of dependencies in core-crossplane-upgrade test

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -7,18 +7,18 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: '1.16'
-  KIND_VERSION: 'v0.11.1'
+  GO_VERSION: '1.18'
+  KIND_VERSION: 'v0.14.0'
 
 jobs:
   crossplane-upgrade-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Crossplane Release 1.1
+      - name: Checkout Crossplane Release 1.9
         uses: actions/checkout@v2
         with:
           repository: crossplane/crossplane
-          ref: release-1.1
+          ref: release-1.9
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -33,7 +33,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.1.0 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.9.0 --wait
         shell: bash
       - name: Run E2E Tests for stable
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: '1.16'
-  KIND_VERSION: 'v0.11.1'
+  GO_VERSION: '1.18'
+  KIND_VERSION: 'v0.14.0'
 
 jobs:
   e2e-tests-latest:
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: crossplane/crossplane
-          ref: release-1.0
+          ref: release-1.9
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -63,7 +63,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.9.0 --wait
         shell: bash
       - name: Run E2E Tests
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: '1.16'
-  KIND_VERSION: 'v0.11.1'
+  GO_VERSION: '1.18'
+  KIND_VERSION: 'v0.14.0'
 
 jobs:
   provider-upgrade-crossplane-stable:
@@ -32,7 +32,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.9.0 --wait
         shell: bash
       - name: Run Provider Upgrade Tests
         run: go test -timeout 10m -v --tags=e2e_provider ./test/...


### PR DESCRIPTION
Debugged the failure of core-crossplane-upgrade tests and found that they were using old versions of dependencies which ended up failing the tests, hence upgraded them to newer versions. Checked with CI and it's working perfectly fine.

Signed-off-by: parul5sahoo <parulsahoo5jan@gmail.com>