### PR TITLE
Add XPKG_TAG var and default to VERSION 

### DIFF
--- a/.github/workflows/package-push.yaml
+++ b/.github/workflows/package-push.yaml
@@ -40,4 +40,4 @@ jobs:
       - name: Publish Packages
         run: make xpkg.push
       - name: Publish Packages to Channel
-        run: VERSION=main make xpkg.push
+        run: XPKG_TAG=main make xpkg.push

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ UP_CHANNEL = stable
 XPKG_REGISTRY ?= us-west1-docker.pkg.dev
 XPKG_ORG ?= crossplane-playground/xp-install-test
 XPKG_REPO ?= configuration
+XPKG_TAG ?= $(VERSION)
 
 # ====================================================================================
 # Targets
@@ -77,8 +78,8 @@ xpkg.push: $(UP)
 	@$(UP) xpkg push \
 		--package $(OUTPUT_DIR)/xpkg/linux_amd64/xp-install-test-configuration-$(VERSION).xpkg \
 		--package $(OUTPUT_DIR)/xpkg/linux_arm64/xp-install-test-configuration-$(VERSION).xpkg \
-		$(XPKG_REGISTRY)/$(XPKG_ORG)/$(XPKG_REPO):$(VERSION) || $(FAIL)
-	@$(OK) Pushed package xp-install-test-configuration-$(VERSION).xpkg
+		$(XPKG_REGISTRY)/$(XPKG_ORG)/$(XPKG_REPO):$(XPKG_TAG) || $(FAIL)
+	@$(OK) Pushed package xp-install-test-configuration-$(VERSION).xpkg to $(XPKG_REGISTRY)/$(XPKG_ORG)/$(XPKG_REPO):$(XPKG_TAG)
 
 build.artifacts.platform: xpkg.build
 


### PR DESCRIPTION
Adds an XPKG_TAG var that defaults to VERSION if not explicitly set.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates to use XPKG_TAG to push to main rather than the current version.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes issue seen in https://github.com/crossplane/test/runs/7846564644?check_suite_focus=true

```
🤖 (test) make xpkg.push -n
echo `date +%H:%M:%S` [ .. ] Pushing package xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg
/home/dan/code/github.com/crossplane/test/.cache/tools/linux_x86_64/up-v0.12.2 xpkg push \
	--package /home/dan/code/github.com/crossplane/test/_output/xpkg/linux_amd64/xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg \
	--package /home/dan/code/github.com/crossplane/test/_output/xpkg/linux_arm64/xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg \
	us-west1-docker.pkg.dev/crossplane-playground/xp-install-test/configuration:v0.0.0-47.g049c510.dirty || (echo `date +%H:%M:%S` [FAIL] && false)
echo `date +%H:%M:%S` [ OK ] Pushed package xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg to us-west1-docker.pkg.dev/crossplane-playground/xp-install-test/configuration:v0.0.0-47.g049c510.dirty
🤖 (test) XPKG_TAG=main make xpkg.push -n
echo `date +%H:%M:%S` [ .. ] Pushing package xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg
/home/dan/code/github.com/crossplane/test/.cache/tools/linux_x86_64/up-v0.12.2 xpkg push \
	--package /home/dan/code/github.com/crossplane/test/_output/xpkg/linux_amd64/xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg \
	--package /home/dan/code/github.com/crossplane/test/_output/xpkg/linux_arm64/xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg \
	us-west1-docker.pkg.dev/crossplane-playground/xp-install-test/configuration:main || (echo `date +%H:%M:%S` [FAIL] && false)
echo `date +%H:%M:%S` [ OK ] Pushed package xp-install-test-configuration-v0.0.0-47.g049c510.dirty.xpkg to us-west1-docker.pkg.dev/crossplane-playground/xp-install-test/configuration:main
```