### PR TITLE
Wrap GAR service account in single quotes

### DIFF
--- a/.github/workflows/private-package.yml
+++ b/.github/workflows/private-package.yml
@@ -38,7 +38,7 @@ jobs:
           --docker-server=us-west1-docker.pkg.dev \
           --docker-email=${{ secrets.GAR_EMAIL }} \
           --docker-username=${{ secrets.GAR_USER }} \
-          --docker-password=${{ secrets.GAR_SA_KEY }}
+          --docker-password='${{ secrets.GAR_SA_KEY }}'
         shell: bash
       - name: Install Latest Crossplane
         run: helm repo add crossplane-master https://charts.crossplane.io/master/ && helm repo update && helm install crossplane --namespace crossplane-system crossplane-master/crossplane --devel --wait


### PR DESCRIPTION
Wraps the GAR service account in single quotes so that it remains scoped
to docker password.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>