### PR TITLE
Only push linux_amd64 configuration package image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ xpkg.push: $(UP)
 	@$(INFO) Pushing package xp-install-test-configuration-$(VERSION).xpkg
 	@$(UP) xpkg push \
 		--package $(OUTPUT_DIR)/xpkg/linux_amd64/xp-install-test-configuration-$(VERSION).xpkg \
-		--package $(OUTPUT_DIR)/xpkg/linux_arm64/xp-install-test-configuration-$(VERSION).xpkg \
 		$(XPKG_REGISTRY)/$(XPKG_ORG)/$(XPKG_REPO):$(XPKG_TAG) || $(FAIL)
 	@$(OK) Pushed package xp-install-test-configuration-$(VERSION).xpkg to $(XPKG_REGISTRY)/$(XPKG_ORG)/$(XPKG_REPO):$(XPKG_TAG)
 


### PR DESCRIPTION
Updates to only push the linux_amd64 variation of the configuration
image. Because configuration packages do not have os / arch constraints,
pushing a multi-arch image results in two manifests, each of which have
no os / arch information.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>