### PR TITLE
Update tests to use v1.11.0 as stable

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -15,11 +15,11 @@ jobs:
   crossplane-upgrade-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Crossplane Release 1.10
+      - name: Checkout Crossplane Release 1.11
         uses: actions/checkout@v2
         with:
           repository: crossplane/crossplane
-          ref: release-1.10
+          ref: release-1.11
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -36,7 +36,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.10.1 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.0 --wait
         shell: bash
       - name: Run E2E Tests for stable
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: crossplane/crossplane
-          ref: release-1.10
+          ref: release-1.11
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -68,7 +68,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.10.1 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.0 --wait
         shell: bash
       - name: Run E2E Tests
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -35,7 +35,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.10.1 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.0 --wait
         shell: bash
       - name: Run Provider Upgrade Tests
         run: go test -timeout 10m -v --tags=e2e_provider ./test/...


### PR DESCRIPTION
This PR updates the workflows in this test repo to use the new [v1.11.0 release](https://github.com/crossplane/crossplane/releases/tag/v1.11.0) of Crossplane.