### PR TITLE
Bump to Crossplane v1.11.3

### DIFF
--- a/.github/workflows/crossplane-upgrade.yml
+++ b/.github/workflows/crossplane-upgrade.yml
@@ -36,7 +36,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.2 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.3 --wait
         shell: bash
       - name: Run E2E Tests for stable
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -68,7 +68,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.2 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.3 --wait
         shell: bash
       - name: Run E2E Tests
         run: go test -p 1 -timeout 10m -v --tags=e2e ./test/e2e/...

--- a/.github/workflows/provider-upgrade.yml
+++ b/.github/workflows/provider-upgrade.yml
@@ -35,7 +35,7 @@ jobs:
         run: kubectl create namespace crossplane-system
         shell: bash
       - name: Install Crossplane from Stable
-        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.2 --wait
+        run: helm repo add crossplane-stable https://charts.crossplane.io/stable && helm repo update && helm install crossplane --namespace crossplane-system crossplane-stable/crossplane --version 1.11.3 --wait
         shell: bash
       - name: Run Provider Upgrade Tests
         run: go test -timeout 10m -v --tags=e2e_provider ./test/...


### PR DESCRIPTION
This PR bumps the Crossplane version of the workflows in this repo to v1.11.3, the latest release of Crossplane.

https://github.com/crossplane/crossplane/releases/tag/v1.11.3 